### PR TITLE
Add configurable tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Modify your ``settings.py`` to integrate ``python-logstash`` with Django's loggi
             'class': 'logstash.LogstashHandler',
             'host': 'localhost',
             'port': 5959,
+            'tags': ['tag1','tag2'],
             'version': 1,
         },
     },

--- a/logstash/handler.py
+++ b/logstash/handler.py
@@ -13,12 +13,14 @@ class TCPLogstashHandler(SocketHandler, object):
     :param version: version of logstash event schema (default is 0).
     """
 
-    def __init__(self, host, port=5959, message_type='logstash', fqdn=False, version=0):
+    def __init__(self, host, port=5959, message_type='logstash', tags=None, fqdn=False, version=0):
         super(TCPLogstashHandler, self).__init__(host, port)
+        if tags is None:
+            tags = []
         if version == 1:
-            self.formatter = formatter.LogstashFormatterVersion1(message_type, [], fqdn)
+            self.formatter = formatter.LogstashFormatterVersion1(message_type, tags, fqdn)
         else:
-            self.formatter = formatter.LogstashFormatterVersion0(message_type, [], fqdn)
+            self.formatter = formatter.LogstashFormatterVersion0(message_type, tags, fqdn)
 
     def makePickle(self, record):
         return self.formatter.format(record) + b'\n'


### PR DESCRIPTION
Quick patch to allow tags to be configured in the log handler and passed to the formatter. The tags setting can be used in a json configuration for dictConfig to set a default list of tags for a logger (README updated to reflect this change too). This should deal with issue #9.
