### PR TITLE
Allow tags kwarg in handler init

### DIFF
--- a/logstash/handler.py
+++ b/logstash/handler.py
@@ -13,12 +13,12 @@ class TCPLogstashHandler(SocketHandler, object):
     :param version: version of logstash event schema (default is 0).
     """
 
-    def __init__(self, host, port=5959, message_type='logstash', fqdn=False, version=0):
+    def __init__(self, host, port=5959, message_type='logstash', tags=None, fqdn=False, version=0):
         super(TCPLogstashHandler, self).__init__(host, port)
         if version == 1:
-            self.formatter = formatter.LogstashFormatterVersion1(message_type, [], fqdn)
+            self.formatter = formatter.LogstashFormatterVersion1(message_type, tags, fqdn)
         else:
-            self.formatter = formatter.LogstashFormatterVersion0(message_type, [], fqdn)
+            self.formatter = formatter.LogstashFormatterVersion0(message_type, tags, fqdn)
 
     def makePickle(self, record):
         return self.formatter.format(record) + b'\n'


### PR DESCRIPTION
Please note that in the formatter.py "tags" are already wired up nicely.
This change simply allows us to pass in a list of tags in the init.
