### PR TITLE
Try to reconnect to rabbitmq if connection is lost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ http://logstash.net/
 
 Changelog
 =========
+0.4.6
+  - Before publishing, reconnects to rabbitmq if connection is closed
 0.4.5
   - Allow passing exchange's routing key to AMQP handler
 0.4.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name='python-logstash',
     packages=['logstash'],
-    version='0.4.5',
+    version='0.4.6',
     description='Python logging handler for Logstash.',
     long_description=open('README.rst').read(),
     author='Volodymyr Klochan',


### PR DESCRIPTION
Sometimes pika raises an exception when tries publish a message:

```
Logged from file control.py, line 270
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 579, in emit
    self.send(s)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 520, in send
    self.sock.sendall(s)
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/logstash/handler_amqp.py", line 123, in sendall
    properties=self.spec)
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 572, in basic_publish
    (properties, body), False)
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 1159, in _send_method
    self.connection.send_method(self.channel_number, method_frame, content)
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 274, in send_method
    self._send_method(channel_number, method_frame, content)
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/connection.py", line 1503, in _send_method
    self._send_frame(frame.Method(channel_number, method_frame))
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 417, in _send_frame
    super(BlockingConnection, self)._send_frame(frame_value)
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/connection.py", line 1490, in _send_frame
    self._flush_outbound()
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 377, in _flush_outbound
    if self._handle_write():
  File "/Users/palam/.virtualenvs/armoury/lib/python2.7/site-packages/pika/adapters/base_connection.py", line 360, in _handle_write
    self.socket.sendall(frame)
AttributeError: 'NoneType' object has no attribute 'sendall'
```

In this fix, pika socket tries to reconnect if any type of connection error happens.
