### PR TITLE
Adding sensitive OpenStack log fields to skip_list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ http://logstash.net/
 
 Changelog
 =========
+0.4.7
+  - Add couple of sensitive fields to the skip_list
 0.4.6
   - Updated field names to match java counterparts supported by logstash crew
 0.4.5

--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -27,7 +27,8 @@ class LogstashFormatterBase(logging.Formatter):
             'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
             'funcName', 'id', 'levelname', 'levelno', 'lineno', 'module',
             'msecs', 'msecs', 'message', 'msg', 'name', 'pathname', 'process',
-            'processName', 'relativeCreated', 'thread', 'threadName', 'extra')
+            'processName', 'relativeCreated', 'thread', 'threadName', 'extra',
+            'auth_token', 'password')
 
         if sys.version_info < (3, 0):
             easy_types = (basestring, bool, dict, float, int, long, list, type(None))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name='python-logstash',
     packages=['logstash'],
-    version='0.4.6',
+    version='0.4.7',
     description='Python logging handler for Logstash.',
     long_description=open('README.rst').read(),
     author='Volodymyr Klochan',


### PR DESCRIPTION
It would be nice if the skip_list was extendable via config file. The OpenStack log files may accidentally include certain sensitive fields and this PR includes the most common sensitive fields to this list.