### PR TITLE
Allow exchange to be declared passively in AMQPLogstashHandler

### DIFF
--- a/logstash/handler_amqp.py
+++ b/logstash/handler_amqp.py
@@ -27,6 +27,9 @@ class AMQPLogstashHandler(SocketHandler, object):
     :param exchange_type: AMQP exchange type (default 'fanout').
     :param durable: AMQP exchange is durable (default False)
     :param virtual_host: AMQP virtual host (default '/').
+    :param passive: exchange is declared passively, meaning that an error is
+        raised if the exchange does not exist, and succeeds otherwise. This is
+        useful if the user does not have configure permission on the exchange.
 
     :param tags: list of tags for a logger (default is None).
     :param message_type: The type of the message (default logstash).
@@ -43,8 +46,8 @@ class AMQPLogstashHandler(SocketHandler, object):
     def __init__(self, host='localhost', port=5672, username='guest',
                  password='guest', exchange='logstash', exchange_type='fanout',
                  virtual_host='/', message_type='logstash', tags=None,
-                 durable=False, version=0, extra_fields=True, fqdn=False,
-                 facility=None, exchange_routing_key=''):
+                 durable=False, passive=False, version=0, extra_fields=True,
+                 fqdn=False, facility=None, exchange_routing_key=''):
 
 
         # AMQP parameters
@@ -55,6 +58,7 @@ class AMQPLogstashHandler(SocketHandler, object):
         self.exchange_type = exchange_type
         self.exchange = exchange
         self.exchange_is_durable = durable
+        self.declare_exchange_passively = passive
         self.virtual_host = virtual_host
         self.routing_key = exchange_routing_key
 
@@ -81,6 +85,7 @@ class AMQPLogstashHandler(SocketHandler, object):
                           self.exchange,
                           self.routing_key,
                           self.exchange_is_durable,
+                          self.declare_exchange_passively,
                           self.exchange_type)
 
     def makePickle(self, record):
@@ -90,7 +95,7 @@ class AMQPLogstashHandler(SocketHandler, object):
 class PikaSocket(object):
 
     def __init__(self, host, port, username, password, virtual_host, exchange,
-                routing_key, durable, exchange_type):
+                routing_key, durable, passive, exchange_type):
 
         # create connection parameters
         credentials = pika.PlainCredentials(username, password)
@@ -104,6 +109,7 @@ class PikaSocket(object):
         # create an exchange, if needed
         self.channel.exchange_declare(exchange=exchange,
                                       exchange_type=exchange_type,
+                                      passive=passive,
                                       durable=durable)
 
         # needed when publishing


### PR DESCRIPTION
It is useful to restrict the user used by the `AMQPLogstashHandler` from making configuration changes on the exchange. This option is already supported by pika's [Channel#declare()](https://pika.readthedocs.io/en/0.10.0/modules/channel.html#pika.channel.Channel.exchange_declare). 

Currently, if the user does not have configure permission on the exchange, then no messages can be logged. This merge request simply adds an optional `passive` parameter to the init method, making this possible without requiring additional permissions.