### PR TITLE
Add KeyValueLogger to avoid having to explicitly use extra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,33 @@ For example::
   }
   test_logger.info('python-logstash: test extra fields', extra=extra)
 
+
+``KeyValueLogger`` is a custom logger which allows you to send extra fields via kwargs.
+
+For example::
+
+  import logging
+  import logstash
+  import sys
+
+  host = 'localhost'
+
+  test_logger = logstash.KeyValueLogger('python-logstash-logger')
+  test_logger.setLevel(logging.INFO)
+  test_logger.addHandler(logstash.LogstashHandler(host, 5959, version=1))
+  # test_logger.addHandler(logstash.TCPLogstashHandler(host, 5959, version=1))
+
+  test_logger.error('python-logstash: test logstash error message.')
+  test_logger.info('python-logstash: test logstash info message.')
+  test_logger.warning('python-logstash: test logstash warning message.')
+
+  # add extra fields to logstash message via kwargs
+  test_logger.info('python-logstash: test extra fields',
+                 test_string='python version: ' + repr(sys.version_info),
+                 test_boolean=True, test_dict={'a': 1, 'b': 'c'},
+                 test_float=1.23, test_integer=123, test_list=[1, 2, '3'])
+
+
 When using ``extra`` field make sure you don't use reserved names. From `Python documentation <https://docs.python.org/2/library/logging.html>`_.
      | "The keys in the dictionary passed in extra should not clash with the keys used by the logging system. (See the `Formatter <https://docs.python.org/2/library/logging.html#logging.Formatter>`_ documentation for more information on which keys are used by the logging system.)"
 

--- a/example3.py
+++ b/example3.py
@@ -1,0 +1,20 @@
+import logging
+import logstash
+import sys
+
+host = 'localhost'
+
+test_logger = logstash.KeyValueLogger('python-logstash-logger')
+test_logger.setLevel(logging.INFO)
+test_logger.addHandler(logstash.LogstashHandler(host, 5959, version=1))
+# test_logger.addHandler(logstash.TCPLogstashHandler(host, 5959, version=1))
+
+test_logger.error('python-logstash: test logstash error message.')
+test_logger.info('python-logstash: test logstash info message.')
+test_logger.warning('python-logstash: test logstash warning message.')
+
+# add extra fields to logstash message via kwargs
+test_logger.info('python-logstash: test extra fields',
+                 test_string='python version: ' + repr(sys.version_info),
+                 test_boolean=True, test_dict={'a': 1, 'b': 'c'},
+                 test_float=1.23, test_integer=123, test_list=[1, 2, '3'])

--- a/logstash/__init__.py
+++ b/logstash/__init__.py
@@ -1,5 +1,6 @@
 
 from logstash.formatter import LogstashFormatterVersion0, LogstashFormatterVersion1
+from logstash.logger import KeyValueLogger
 
 from logstash.handler_tcp import TCPLogstashHandler
 from logstash.handler_udp import UDPLogstashHandler, LogstashHandler

--- a/logstash/logger.py
+++ b/logstash/logger.py
@@ -1,0 +1,11 @@
+import logging
+
+
+class KeyValueLogger(logging.Logger):
+    """A logger that passes kwargs on to the Logstash logger via `extra`. """
+
+    def _log(self, level, msg, args, exc_info=None, extra=None,
+             stack_info=False, **kwargs):
+        extra = extra or {}
+        extra.update(**kwargs)
+        super()._log(level, msg, args, exc_info, extra, stack_info)


### PR DESCRIPTION
This PR adds the `KeyValueLogger` class, which basically just packs all kwargs into the `extra` parameter:
```python
test_logger = KeyValueLogger('python-logstash-logger')
# set up...
test_logger.info('python-logstash: test extra fields',
                 test_string='python version: ' + repr(sys.version_info),
                 test_boolean=True, test_dict={'a': 1, 'b': 'c'},
                 test_float=1.23, test_integer=123, test_list=[1, 2, '3'])
```

This is something I think would be helpful to others, but I understand if it's outside the scope of the project. The use case for us looks something like this:
```python
logger.info('SOME_EVENT', foo='bar', fizz='bazz', ...)
``` 
Where our current logging setup allows us to essentially specify an event (e.g. NEW_REQUEST, APP_INSTALLED, HOST_UNREACHABLE, etc), plus some additional info about the event. 

Let me know what you think and whether you have any feedback.