### PR TITLE
Try to reconnect if connection is lost (replace pika with kombu)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,9 @@ For example::
 When using ``extra`` field make sure you don't use reserved names. From `Python documentation <https://docs.python.org/2/library/logging.html>`_.
      | "The keys in the dictionary passed in extra should not clash with the keys used by the logging system. (See the `Formatter <https://docs.python.org/2/library/logging.html#logging.Formatter>`_ documentation for more information on which keys are used by the logging system.)"
 
-To use the AMQPLogstashHandler you will need to install pika first.
+To use the AMQPLogstashHandler you will need to install kombu first.
 
-   pip install pika
+   pip install kombu
 
 For example::
 

--- a/logstash/handler_amqp.py
+++ b/logstash/handler_amqp.py
@@ -1,4 +1,5 @@
 import json
+
 try:
     from urllib import urlencode
 except ImportError:
@@ -7,7 +8,8 @@ except ImportError:
 from logging import Filter
 from logging.handlers import SocketHandler
 
-import pika
+from kombu import Connection, Exchange, producers
+
 from logstash import formatter
 
 
@@ -76,54 +78,45 @@ class AMQPLogstashHandler(SocketHandler, object):
         self.facility = facility
 
     def makeSocket(self, **kwargs):
-
-        return PikaSocket(self.host,
-                          self.port,
-                          self.username,
-                          self.password,
-                          self.virtual_host,
-                          self.exchange,
-                          self.routing_key,
-                          self.exchange_is_durable,
-                          self.declare_exchange_passively,
-                          self.exchange_type)
+        return KombuSocket(self.host,
+                           self.port,
+                           self.username,
+                           self.password,
+                           self.virtual_host,
+                           self.exchange,
+                           self.routing_key,
+                           self.exchange_is_durable,
+                           self.declare_exchange_passively,
+                           self.exchange_type)
 
     def makePickle(self, record):
         return self.formatter.format(record)
 
 
-class PikaSocket(object):
+class KombuSocket(object):
 
     def __init__(self, host, port, username, password, virtual_host, exchange,
                 routing_key, durable, passive, exchange_type):
+        # create connection
+        self.connection = Connection(hostname=host,
+                                     port=port,
+                                     userid=username,
+                                     password=password,
+                                     virtual_host=virtual_host)
 
-        # create connection parameters
-        credentials = pika.PlainCredentials(username, password)
-        parameters = pika.ConnectionParameters(host, port, virtual_host,
-                                               credentials)
+        # create exchange
+        self.exchange = Exchange(exchange, type=exchange_type, durable=durable)
+        self.exchange.passive = passive
 
-        # create connection & channel
-        self.connection = pika.BlockingConnection(parameters)
-        self.channel = self.connection.channel()
-
-        # create an exchange, if needed
-        self.channel.exchange_declare(exchange=exchange,
-                                      exchange_type=exchange_type,
-                                      passive=passive,
-                                      durable=durable)
-
-        # needed when publishing
-        self.spec = pika.spec.BasicProperties(delivery_mode=2)
+        # other publishing params
         self.routing_key = routing_key
-        self.exchange = exchange
-
 
     def sendall(self, data):
-
-        self.channel.basic_publish(self.exchange,
-                                   self.routing_key,
-                                   data,
-                                   properties=self.spec)
+        with producers[self.connection].acquire(block=True) as producer:
+            producer.publish(data,
+                             routing_key=self.routing_key,
+                             exchange=self.exchange,
+                             declare=[self.exchange])
 
     def close(self):
         try:

--- a/logstash/handler_amqp.py
+++ b/logstash/handler_amqp.py
@@ -1,12 +1,9 @@
-import json
+from logging.handlers import SocketHandler
 
 try:
     from urllib import urlencode
 except ImportError:
     from urllib.parse import urlencode
-
-from logging import Filter
-from logging.handlers import SocketHandler
 
 from kombu import Connection, Exchange, producers
 


### PR DESCRIPTION
I need the `AMQPLogstashHandler` to gracefully handle connection failure. Rather than implement this logic in the library as in #34, I recommend switching from pika to [kombu](https://github.com/celery/kombu). 

In this PR I essentially just swapped the two libraries and made updates necessary to accommodate that change. This implementation uses kombu's [producers pool](http://docs.celeryproject.org/projects/kombu/en/latest/userguide/pools.html#the-producer-pool-group) for publishing, which handles connection failure gracefully. It might also be a good idea to add a max pool size option to the `AMQPLogstashHandler` (see [setting pool limits](http://docs.celeryproject.org/projects/kombu/en/latest/userguide/pools.html#setting-pool-limits)). 

I also updated the socket logic to be more compatible with the `SocketHandler` class. With the current implementation, we are made aware of connection problems because pika raises `pika.exceptions.ConnectionClosed`, which escapes the [except-block in SocketHandler.createSocket()](https://hg.python.org/cpython/file/tip/Lib/logging/handlers.py#l558). With kombu, `OSErrors` are raised, which get silently swallowed, so I had to add a modified `send()`. 
