### PR TITLE
Use str() when json.dumps() finds an unserializable record

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -29,21 +29,10 @@ class LogstashFormatterBase(logging.Formatter):
             'msecs', 'msecs', 'message', 'msg', 'name', 'pathname', 'process',
             'processName', 'relativeCreated', 'thread', 'threadName', 'extra',
             'auth_token', 'password')
-
-        if sys.version_info < (3, 0):
-            easy_types = (basestring, bool, dict, float, int, long, list, type(None))
-        else:
-            easy_types = (str, bool, dict, float, int, list, type(None))
-
         fields = {}
-
         for key, value in record.__dict__.items():
             if key not in skip_list:
-                if isinstance(value, easy_types):
-                    fields[key] = value
-                else:
-                    fields[key] = repr(value)
-
+                fields[key] = value
         return fields
 
     def get_debug_fields(self, record):

--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -79,10 +79,10 @@ class LogstashFormatterBase(logging.Formatter):
 
     @classmethod
     def serialize(cls, message):
-        if sys.version_info < (3, 0):
-            return json.dumps(message)
-        else:
-            return bytes(json.dumps(message), 'utf-8')
+        data = json.dumps(message, default=str)
+        if sys.version_info >= (3, 0):
+            data = bytes(data, 'utf-8')
+        return data
 
 class LogstashFormatterVersion0(LogstashFormatterBase):
     version = 0


### PR DESCRIPTION
Hi @vklochan 

I ran into a logging error today involving a non-json serializable value in a situation similar to the following:
```python
test_logger.info('testing', extra={'test_dict': {'foo': object()}})
```

Which would result in: 
```shell
TypeError: <object object at 0x7f768bcef130> is not JSON serializable
```

Some of this is prevented in [formatter.py#L45](https://github.com/vklochan/python-logstash/blob/master/logstash/formatter.py#L45) where `repr()` is called on any non "easy" types. This is essentially what adding the default argument to `json.dumps()` would do, with the addition that it would also take care of nested structures. I can of course update my PR to use `repr()` instead of `str()`.
