### PR TITLE
allow source host override

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,7 @@ Modify your ``settings.py`` to integrate ``python-logstash`` with Django's loggi
             'message_type': 'logstash',  # 'type' field in logstash message. Default value: 'logstash'.
             'fqdn': False, # Fully qualified domain name. Default value: false.
             'tags': ['tag1', 'tag2'], # list of tags. Default: None.
+            'source_host': 'my.app.com' # Manually override the source host sent to logstash. If set, hostname lookup will be skipped
         },
     },
     'loggers': {

--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -11,11 +11,14 @@ except ImportError:
 
 class LogstashFormatterBase(logging.Formatter):
 
-    def __init__(self, message_type='Logstash', tags=None, fqdn=False):
+    def __init__(self, message_type='Logstash', tags=None, fqdn=False,
+                 source_host=None):
         self.message_type = message_type
         self.tags = tags if tags is not None else []
 
-        if fqdn:
+        if source_host is not None:
+            self.host = source_host
+        elif fqdn:
             self.host = socket.getfqdn()
         else:
             self.host = socket.gethostname()


### PR DESCRIPTION
When running applications inside of docker containers, it can be handy to manually set the source hostname sent to logstash, since docker generates a random hostname when a container is created.