### PR TITLE
format tuple as list (vs. string)

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -31,9 +31,9 @@ class LogstashFormatterBase(logging.Formatter):
             'auth_token', 'password')
 
         if sys.version_info < (3, 0):
-            easy_types = (basestring, bool, dict, float, int, long, list, type(None))
+            easy_types = (basestring, bool, dict, float, int, long, list, tuple, type(None))
         else:
-            easy_types = (str, bool, dict, float, int, list, type(None))
+            easy_types = (str, bool, dict, float, int, list, tuple, type(None))
 
         fields = {}
 


### PR DESCRIPTION
Prior to this change, a `tuple` was pushed to logstash as a string (i.e., using its `__repr__`). Now that it's been added as an `easy_type`, python automatically converts it to a list (upon dumping as JSON).