### PR TITLE
Added 'stack_info' to the skip_list

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -28,7 +28,7 @@ class LogstashFormatterBase(logging.Formatter):
             'funcName', 'id', 'levelname', 'levelno', 'lineno', 'module',
             'msecs', 'msecs', 'message', 'msg', 'name', 'pathname', 'process',
             'processName', 'relativeCreated', 'thread', 'threadName', 'extra',
-            'auth_token', 'password')
+            'auth_token', 'password', 'stack_info')
 
         if sys.version_info < (3, 0):
             easy_types = (basestring, bool, dict, float, int, long, list, type(None))


### PR DESCRIPTION
According to the issue, #85, the 'stack_info' has been added to the skip_list.
This field is standard and can be appeared only with python 3.