### PR TITLE
docs: fix simple typo, paramaters -> parameters

### DIFF
--- a/logstash/handler_amqp.py
+++ b/logstash/handler_amqp.py
@@ -64,7 +64,7 @@ class AMQPLogstashHandler(SocketHandler, object):
 
         SocketHandler.__init__(self, host, port)
 
-        # Extract Logstash paramaters
+        # Extract Logstash parameters
         self.tags = tags or []
         fn = formatter.LogstashFormatterVersion1 if version == 1 \
             else formatter.LogstashFormatterVersion0


### PR DESCRIPTION
There is a small typo in logstash/handler_amqp.py.

Should read `parameters` rather than `paramaters`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md