### PR TITLE
Object of type 'datetime' is not JSON serializable

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -82,7 +82,7 @@ class LogstashFormatterBase(logging.Formatter):
         if sys.version_info < (3, 0):
             return json.dumps(message)
         else:
-            return bytes(json.dumps(message), 'utf-8')
+            return bytes(json.dumps(message, default=str), 'utf-8')
 
 class LogstashFormatterVersion0(LogstashFormatterBase):
     version = 0


### PR DESCRIPTION
Fixed error message `Object of type 'datetime' is not JSON serializable`

This problem is also bein known as the following issues: #59  #60
