### PR TITLE
Object of type 'datetime' is not JSON serializable - DEV

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ http://logstash.net/
 
 Changelog
 =========
+0.4.8
+  - Fixed Python 3 issues with JSON serialization.
 0.4.7
   - Add couple of sensitive fields to the skip_list
 0.4.6

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name='python-logstash',
     packages=['logstash'],
-    version='0.4.7',
+    version='0.4.8',
     description='Python logging handler for Logstash.',
     long_description=open('README.rst').read(),
     license='MIT',


### PR DESCRIPTION
- Added a new version in the README changes log. 
- Changed setup version. 