### PR TITLE
Update hostname for version1

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -122,7 +122,7 @@ class LogstashFormatterVersion1(LogstashFormatterBase):
             '@timestamp': self.format_timestamp(record.created),
             '@version': '1',
             'message': record.getMessage(),
-            'host': self.host,
+            'host': {'hostname': self.host},
             'path': record.pathname,
             'tags': self.tags,
             'type': self.message_type,


### PR DESCRIPTION
logstash/formatter.py:
   * On logstash 8.x (maybe earlier too), the ip of the sender will be
the field "host":{"ip": sender_ip}
```
logstash         | {
logstash         |          "event" => {
logstash         |         "original" => "{}\n"
logstash         |     },
logstash         |       "@version" => "1",
logstash         |           "host" => {
logstash         |         "ip" => "172.21.56.1"
logstash         |     },
logstash         |     "@timestamp" => 2022-04-22T00:23:19.214302Z
```
So when we send the field "host": hostname, it will cause json parsing
error in logstash receiver.

Signed-off-by: Tuan T. Pham <tuan@greenfly.io>