### PR TITLE
change json dumps parameter to show chinese log content correctly

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -80,9 +80,9 @@ class LogstashFormatterBase(logging.Formatter):
     @classmethod
     def serialize(cls, message):
         if sys.version_info < (3, 0):
-            return json.dumps(message)
+            return json.dumps(message, ensure_ascii=False)
         else:
-            return bytes(json.dumps(message, default=str), 'utf-8')
+            return bytes(json.dumps(message, default=str, ensure_ascii=False), 'utf-8')
 
 class LogstashFormatterVersion0(LogstashFormatterBase):
     version = 0


### PR DESCRIPTION
When using `json.dumps(message)`, if the `message` contains chinese, it will be displayed as unicode like "\u4f60\u597d", so it's better to add `ensure_ascii=False` to display chinese log content correctly.