### PR TITLE
Distutils has been deprecated in Python 3.10 #96

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
-from distutils.core import setup
+import sys
+
+if sys.version_info < (3, 7):
+    from distutils.core import setup
+else:
+    from setuptools import setup
+
 setup(
     name='python-logstash',
     packages=['logstash'],


### PR DESCRIPTION
https://github.com/vklochan/python-logstash/issues/96